### PR TITLE
fix 'ReferenceError: error is not defined'

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -118,7 +118,7 @@ function ciede2000(c1,c2)
     else if(abs(h2p-h1p) <= 180) return h2p-h1p;
     else if((h2p-h1p) > 180)     return (h2p-h1p)-360;
     else if((h2p-h1p) < -180)    return (h2p-h1p)+360;
-    else                         throw(error);
+    else                         throw(new Error());
   }
   var dhp = dhp_f(C1,C2, h1p, h2p); //(10)
   var dHp = 2*sqrt(C1p*C2p)*sin(radians(dhp)/2.0); //(11)
@@ -134,7 +134,7 @@ function ciede2000(c1,c2)
     else if(abs(h1p-h2p)<= 180)                         return (h1p+h2p)/2.0;
     else if((abs(h1p-h2p) > 180) && ((h1p+h2p) < 360))  return (h1p+h2p+360)/2.0;
     else if((abs(h1p-h2p) > 180) && ((h1p+h2p) >= 360)) return (h1p+h2p-360)/2.0;
-    else                                                throw(error);
+    else                                                throw(new Error());
   }
   var a_hp = a_hp_f(C1,C2,h1p,h2p); //(14)
   var T = 1-0.17*cos(radians(a_hp-30))+0.24*cos(radians(2*a_hp))+


### PR DESCRIPTION
There is no variable 'error' defined, so the error case fails. I changed it to throw a new generic Error which fixes the problem.
