### PR TITLE
Guard against external libraries modifying Array.prototype

### DIFF
--- a/lib/palette.js
+++ b/lib/palette.js
@@ -63,11 +63,11 @@ function map_palette(a, b, type)
 {
   var c = {};
   type = type || 'closest';
-  for (var idx1 in a){
+  for (var idx1 = 0; idx1 < a.length; idx1 += 1){
     var color1 = a[idx1];
     var best_color      = undefined;
     var best_color_diff = undefined;
-    for (var idx2 in b)
+    for (var idx2 = 0; idx2 < b.length; idx2 += 1)
     {
       var color2 = b[idx2];
       var current_color_diff = diff(color1,color2);


### PR DESCRIPTION
When running color-diff in an environment where `Array.prototype` has been amended with helper functions, the palette will some times return color objects with `NaN` in every dimension.

I tried using a `for(var idx1; idx1 < a.length; idx1 += 1)` loop, which would be cleaner, but when I do the tests are failing.