### PR TITLE
Performance improvements

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -93,16 +93,6 @@ function ciede2000(c1,c2)
   var C1p = sqrt(pow(a1p, 2) + pow(b1, 2)); //(6)
   var C2p = sqrt(pow(a2p, 2) + pow(b2, 2)); //(6)
 
-  var hp_f = function(x,y) //(7)
-  {
-    if(x== 0 && y == 0) return 0;
-    else{
-      var tmphp = degrees(atan2(x,y));
-      if(tmphp >= 0) return tmphp
-      else           return tmphp + 360;
-    }
-  }
-
   var h1p = hp_f(b1, a1p); //(7)
   var h2p = hp_f(b2, a2p); //(7)
 
@@ -112,14 +102,6 @@ function ciede2000(c1,c2)
   var dLp = L2 - L1; //(8)
   var dCp = C2p - C1p; //(9)
 
-  var dhp_f = function(C1, C2, h1p, h2p) //(10)
-  {
-    if(C1*C2 == 0)               return 0;
-    else if(abs(h2p-h1p) <= 180) return h2p-h1p;
-    else if((h2p-h1p) > 180)     return (h2p-h1p)-360;
-    else if((h2p-h1p) < -180)    return (h2p-h1p)+360;
-    else                         throw(new Error());
-  }
   var dhp = dhp_f(C1,C2, h1p, h2p); //(10)
   var dHp = 2*sqrt(C1p*C2p)*sin(radians(dhp)/2.0); //(11)
 
@@ -129,13 +111,6 @@ function ciede2000(c1,c2)
   var a_L = (L1 + L2) / 2.0; //(12)
   var a_Cp = (C1p + C2p) / 2.0; //(13)
 
-  var a_hp_f = function(C1, C2, h1p, h2p) { //(14)
-    if(C1*C2 == 0)                                      return h1p+h2p
-    else if(abs(h1p-h2p)<= 180)                         return (h1p+h2p)/2.0;
-    else if((abs(h1p-h2p) > 180) && ((h1p+h2p) < 360))  return (h1p+h2p+360)/2.0;
-    else if((abs(h1p-h2p) > 180) && ((h1p+h2p) >= 360)) return (h1p+h2p-360)/2.0;
-    else                                                throw(new Error());
-  }
   var a_hp = a_hp_f(C1,C2,h1p,h2p); //(14)
   var T = 1-0.17*cos(radians(a_hp-30))+0.24*cos(radians(2*a_hp))+
     0.32*cos(radians(3*a_hp+6))-0.20*cos(radians(4*a_hp-63)); //(15)
@@ -157,6 +132,33 @@ function ciede2000(c1,c2)
  */
 function degrees(n) { return n*(180/PI); }
 function radians(n) { return n*(PI/180); }
+
+function hp_f(x,y) //(7)
+{
+  if(x== 0 && y == 0) return 0;
+  else{
+    var tmphp = degrees(atan2(x,y));
+    if(tmphp >= 0) return tmphp
+    else           return tmphp + 360;
+  }
+}
+
+function dhp_f(C1, C2, h1p, h2p) //(10)
+{
+  if(C1*C2 == 0)               return 0;
+  else if(abs(h2p-h1p) <= 180) return h2p-h1p;
+  else if((h2p-h1p) > 180)     return (h2p-h1p)-360;
+  else if((h2p-h1p) < -180)    return (h2p-h1p)+360;
+  else                         throw(new Error());
+}
+
+function a_hp_f(C1, C2, h1p, h2p) { //(14)
+  if(C1*C2 == 0)                                      return h1p+h2p
+  else if(abs(h1p-h2p)<= 180)                         return (h1p+h2p)/2.0;
+  else if((abs(h1p-h2p) > 180) && ((h1p+h2p) < 360))  return (h1p+h2p+360)/2.0;
+  else if((abs(h1p-h2p) > 180) && ((h1p+h2p) >= 360)) return (h1p+h2p-360)/2.0;
+  else                                                throw(new Error());
+}
 
 // Local Variables:
 // allout-layout: t

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -135,7 +135,7 @@ function radians(n) { return n*(PI/180); }
 
 function hp_f(x,y) //(7)
 {
-  if(x== 0 && y == 0) return 0;
+  if(x === 0 && y === 0) return 0;
   else{
     var tmphp = degrees(atan2(x,y));
     if(tmphp >= 0) return tmphp
@@ -145,7 +145,7 @@ function hp_f(x,y) //(7)
 
 function dhp_f(C1, C2, h1p, h2p) //(10)
 {
-  if(C1*C2 == 0)               return 0;
+  if(C1*C2 === 0)              return 0;
   else if(abs(h2p-h1p) <= 180) return h2p-h1p;
   else if((h2p-h1p) > 180)     return (h2p-h1p)-360;
   else if((h2p-h1p) < -180)    return (h2p-h1p)+360;
@@ -153,7 +153,7 @@ function dhp_f(C1, C2, h1p, h2p) //(10)
 }
 
 function a_hp_f(C1, C2, h1p, h2p) { //(14)
-  if(C1*C2 == 0)                                      return h1p+h2p
+  if(C1*C2 === 0)                                     return h1p+h2p
   else if(abs(h1p-h2p)<= 180)                         return (h1p+h2p)/2.0;
   else if((abs(h1p-h2p) > 180) && ((h1p+h2p) < 360))  return (h1p+h2p+360)/2.0;
   else if((abs(h1p-h2p) > 180) && ((h1p+h2p) >= 360)) return (h1p+h2p-360)/2.0;

--- a/lib/palette.js
+++ b/lib/palette.js
@@ -35,7 +35,7 @@ exports.palette_map_key = palette_map_key;
 /**
 * IMPORTS
 */
-var color_diff    = require('./diff');
+var ciede2000     = require('./diff').ciede2000;
 var color_convert = require('./convert');
 
 /**
@@ -114,7 +114,7 @@ function diff(c1, c2, bc)
   }
   c1 = conv_c1(c1);
   c2 = conv_c2(c2);
-  return color_diff.ciede2000(c1, c2);
+  return ciede2000(c1, c2);
 }
 
 // Local Variables:


### PR DESCRIPTION
Hoisting the functions to the outer scope increases performance by about 20%. The other tweaks move the needle by the tiniest amount, but in the right direction.

master branch:
```
rnd.gen 2.9628049787171404 ± 0.14880101230839793
colorDiff.closest 181.64721476923273 ± 7.260007105342422
colorDiff.closest [predef] 171.09526993905783 ± 7.195477461087955
```

performance branch:
```
rnd.gen 2.973347308582935 ± 0.20252592561612162
colorDiff.closest 155.08481424744338 ± 5.489338215168882
colorDiff.closest [predef] 143.9483535199002 ± 3.7500997878289497
```

<details>
<summary>Click to reveal the benchmark code</summary>

```js
const Benchmark = require('benchmark');
const colorDiff = require('./lib');

const suite = new Benchmark.Suite;

const rnd = function () {
  return {
    R: Math.floor(Math.random() * 256),
    G: Math.floor(Math.random() * 256),
    B: Math.floor(Math.random() * 256),
  };
};

const rndA = function () {
  return [
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
  ];
};

const predefTarget = rnd();
const predefPalette = rndA();

suite
  .add('rnd.gen', function () {
    return [rnd(), rndA()];
  })
  .add('colorDiff.closest', function () {
    return colorDiff.closest(rnd(), rndA());
  })
  .add('colorDiff.closest [predef]', function () {
    return colorDiff.closest(predefTarget, predefPalette);
  })
  .on('complete', function () {
    for (let i = 0; i < 3; i += 1) {
      console.log(this[i].name, this[i].stats.mean * 1000000, '±', this[i].stats.deviation * 1000000);
    }
  })
  .run({});
```
</details>