### PR TITLE
DX: Allow using a prepared palette for performance, enable receiving/returning hex colors

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -31,6 +31,7 @@
 */
 exports.rgb_to_lab = rgb_to_lab;
 exports.rgba_to_lab = rgba_to_lab;
+exports.hex_to_rgb = hex_to_rgb;
 
 /**
 * IMPORTS
@@ -41,6 +42,21 @@ var sqrt = Math.sqrt;
 /**
  * API FUNCTIONS
  */
+
+/**
+* Returns hex string c converted to rgbcolor.
+* @param {rgbcolor} c should be exactly 7 characters long: #rrggbb
+* @return {rgbcolor} c converted to rgbcolor
+*/
+function hex_to_rgb(c)
+{
+  return {
+    R: parseInt(c.substr(1, 2), 16),
+    G: parseInt(c.substr(3, 2), 16),
+    B: parseInt(c.substr(5, 2), 16),
+  };
+}
+
 
 /**
 * Returns c converted to labcolor. Uses bc as background color,

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -31,6 +31,7 @@
 */
 exports.rgb_to_lab = rgb_to_lab;
 exports.rgba_to_lab = rgba_to_lab;
+exports.rgb_or_rgba_to_lab = rgb_or_rgba_to_lab;
 exports.hex_to_rgb = hex_to_rgb;
 
 /**
@@ -82,6 +83,21 @@ function rgba_to_lab(c, bc)
 function rgb_to_lab(c)
 {
   return xyz_to_lab(rgb_to_xyz(c))
+}
+
+/**
+* Returns c converted to labcolor. Uses bc as background color,
+* deaults to using white as background color.
+* @param {rgbcolor} bc should have fields R,G,B
+* @param {rgbcolor|rgbacolor} c should have fields R,G,B or R,G,B,A
+* @return {labcolor} c converted to labcolor
+*/
+function rgb_or_rgba_to_lab(bc, c) {
+  if ("A" in c) {
+    return rgba_to_lab(c, bc);
+  } else {
+    return rgb_to_lab(c);
+  }
 }
 
 /**

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -29,10 +29,10 @@
 /**
 * EXPORTS
 */
-exports.rgb_to_lab = rgb_to_lab;
-exports.rgba_to_lab = rgba_to_lab;
+exports.rgb_to_lab         = rgb_to_lab;
+exports.rgba_to_lab        = rgba_to_lab;
 exports.rgb_or_rgba_to_lab = rgb_or_rgba_to_lab;
-exports.hex_to_rgb = hex_to_rgb;
+exports.hex_to_rgb         = hex_to_rgb;
 
 /**
 * IMPORTS
@@ -57,7 +57,6 @@ function hex_to_rgb(c)
     B: parseInt(c.substr(5, 2), 16),
   };
 }
-
 
 /**
 * Returns c converted to labcolor. Uses bc as background color,
@@ -92,7 +91,8 @@ function rgb_to_lab(c)
 * @param {rgbcolor|rgbacolor} c should have fields R,G,B or R,G,B,A
 * @return {labcolor} c converted to labcolor
 */
-function rgb_or_rgba_to_lab(bc, c) {
+function rgb_or_rgba_to_lab(bc, c)
+{
   if ("A" in c) {
     return rgba_to_lab(c, bc);
   } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ color.process = function(target, relative, findFurthest, bc) {
     var key = color.palette_map_key(targetRGB);
     bc = typeof bc !== 'undefined' ? bc : {R: 255, G: 255, B:255};
     var result = color.map_palette([targetRGB], relativeRGB, (findFurthest ? 'furthest' : 'closest'), bc);
-    if (typeof relative === 'string') {
+    if (typeof target === 'string') {
       return relative[relativeRGB.indexOf(result[key])];
     } else {
       return result[key];

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,41 +15,41 @@ color.map_palette_lab     = palette.map_palette_lab;
 color.lab_palette_map_key = palette.lab_palette_map_key;
 color.match_palette_lab   = palette.match_palette_lab;
 
-color.process = function(target, relative, findFurthest, bc) {
-    if (relative.prepared) {
-      var targetLab = convert.rgb_or_rgba_to_lab(bc, marshall(target));
-      var resultLab = color.palette_lab(targetLab, relative.lab, findFurthest);
-      return relative.original[relative.lab.indexOf(resultLab)];
-    }
-    var targetRGB = marshall(target);
-    var relativeRGB = relative.map(marshall);
-    var key = color.palette_map_key(targetRGB);
-    bc = typeof bc !== 'undefined' ? bc : {R: 255, G: 255, B:255};
-    var result = color.map_palette([targetRGB], relativeRGB, (findFurthest ? 'furthest' : 'closest'), bc);
-    if (typeof target === 'string') {
-      return relative[relativeRGB.indexOf(result[key])];
-    } else {
-      return result[key];
-    }
+color.process = function(target, relative, find_furthest, bc) {
+  if (relative.prepared) {
+    var target_lab = convert.rgb_or_rgba_to_lab(bc, marshall(target));
+    var result_lab = color.match_palette_lab(target_lab, relative.lab, find_furthest);
+    return relative.original[relative.lab.indexOf(result_lab)];
+  }
+  var target_rgb = marshall(target);
+  var relative_rgb = relative.map(marshall);
+  var key = color.palette_map_key(target_rgb);
+  bc = typeof bc !== 'undefined' ? bc : {R: 255, G: 255, B:255};
+  var result = color.map_palette([target_rgb], relative_rgb, (find_furthest ? 'furthest' : 'closest'), bc);
+  if (typeof target === 'string') {
+    return relative[relative_rgb.indexOf(result[key])];
+  } else {
+    return result[key];
+  }
 };
 
 color.closest = function(target, relative, bc) {
-    return color.process(target, relative, false, bc);
+  return color.process(target, relative, false, bc);
 }
 
 color.furthest = function(target, relative, bc) {
-    return color.process(target, relative, true, bc);
+  return color.process(target, relative, true, bc);
 };
 
 color.closest_lab = function(target, relative) {
-    return color.match_palette_lab(target, relative, false);
+  return color.match_palette_lab(target, relative, false);
 };
 
 color.furthest_lab = function(target, relative) {
-    return color.match_palette_lab(target, relative, true);
+  return color.match_palette_lab(target, relative, true);
 };
 
-color.preparePalette = function(relative, bc) {
+color.prepare_palette = function(relative, bc) {
   return {
     prepared: true,
     original: relative,

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,12 +15,12 @@ color.map_palette_lab     = palette.map_palette_lab;
 color.lab_palette_map_key = palette.lab_palette_map_key;
 color.match_palette_lab   = palette.match_palette_lab;
 
-color.closest = function(target, relative, bc) {
+color.process = function(target, relative, findFurthest, bc) {
     var targetRGB = marshall(target);
     var relativeRGB = relative.map(marshall);
     var key = color.palette_map_key(targetRGB);
     bc = typeof bc !== 'undefined' ? bc : {R: 255, G: 255, B:255};
-    var result = color.map_palette([targetRGB], relativeRGB, 'closest', bc);
+    var result = color.map_palette([targetRGB], relativeRGB, (findFurthest ? 'furthest' : 'closest'), bc);
     if (typeof relative === 'string') {
       return relative[relativeRGB.indexOf(result[key])];
     } else {
@@ -28,18 +28,13 @@ color.closest = function(target, relative, bc) {
     }
 };
 
-color.furthest = function(target, relative, bc) {
-    var targetRGB = marshall(target);
-    var relativeRGB = relative.map(marshall);
-    var key = color.palette_map_key(targetRGB);
-    bc = typeof bc !== 'undefined' ? bc : {R: 255, G: 255, B:255};
-    var result = color.map_palette([targetRGB], relativeRGB, 'furthest', bc);
+color.closest = function(target, relative, bc) {
+    color.process(target, relative, false, bc);
+}
 
-    if (typeof relative === 'string') {
-      return relative[relativeRGB.indexOf(result[key])];
-    } else {
-      return result[key];
-    }
+
+color.furthest = function(target, relative, bc) {
+    color.process(target, relative, true, bc);
 };
 
 color.closest_lab = function(target, relative) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,11 +26,7 @@ color.process = function(target, relative, find_furthest, bc) {
   var key = color.palette_map_key(target_rgb);
   bc = typeof bc !== 'undefined' ? bc : {R: 255, G: 255, B:255};
   var result = color.map_palette([target_rgb], relative_rgb, (find_furthest ? 'furthest' : 'closest'), bc);
-  if (typeof target === 'string') {
-    return relative[relative_rgb.indexOf(result[key])];
-  } else {
-    return result[key];
-  }
+  return relative[relative_rgb.indexOf(result[key])];
 };
 
 color.closest = function(target, relative, bc) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,19 +16,30 @@ color.lab_palette_map_key = palette.lab_palette_map_key;
 color.match_palette_lab   = palette.match_palette_lab;
 
 color.closest = function(target, relative, bc) {
-    var key = color.palette_map_key(target);
+    var targetRGB = marshall(target);
+    var relativeRGB = relative.map(marshall);
+    var key = color.palette_map_key(targetRGB);
     bc = typeof bc !== 'undefined' ? bc : {R: 255, G: 255, B:255};
-    var result = color.map_palette([target], relative, 'closest', bc);
-
-    return result[key];
+    var result = color.map_palette([targetRGB], relativeRGB, 'closest', bc);
+    if (typeof relative === 'string') {
+      return relative[relativeRGB.indexOf(result[key])];
+    } else {
+      return result[key];
+    }
 };
 
 color.furthest = function(target, relative, bc) {
-    var key = color.palette_map_key(target);
+    var targetRGB = marshall(target);
+    var relativeRGB = relative.map(marshall);
+    var key = color.palette_map_key(targetRGB);
     bc = typeof bc !== 'undefined' ? bc : {R: 255, G: 255, B:255};
-    var result = color.map_palette([target], relative, 'furthest', bc);
+    var result = color.map_palette([targetRGB], relativeRGB, 'furthest', bc);
 
-    return result[key];
+    if (typeof relative === 'string') {
+      return relative[relativeRGB.indexOf(result[key])];
+    } else {
+      return result[key];
+    }
 };
 
 color.closest_lab = function(target, relative) {
@@ -38,3 +49,12 @@ color.closest_lab = function(target, relative) {
 color.furthest_lab = function(target, relative) {
     return color.match_palette_lab(target, relative, true);
 };
+
+function marshall(c)
+{
+  if (typeof c === 'string') {
+    return convert.hex_to_rgb(c);
+  } else {
+    return c;
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,11 @@ color.lab_palette_map_key = palette.lab_palette_map_key;
 color.match_palette_lab   = palette.match_palette_lab;
 
 color.process = function(target, relative, findFurthest, bc) {
+    if (relative.prepared) {
+      var targetLab = convert.rgb_or_rgba_to_lab(bc, marshall(target));
+      var resultLab = color.palette_lab(targetLab, relative.lab, findFurthest);
+      return relative.original[relative.lab.indexOf(resultLab)];
+    }
     var targetRGB = marshall(target);
     var relativeRGB = relative.map(marshall);
     var key = color.palette_map_key(targetRGB);
@@ -32,7 +37,6 @@ color.closest = function(target, relative, bc) {
     color.process(target, relative, false, bc);
 }
 
-
 color.furthest = function(target, relative, bc) {
     color.process(target, relative, true, bc);
 };
@@ -45,8 +49,15 @@ color.furthest_lab = function(target, relative) {
     return color.match_palette_lab(target, relative, true);
 };
 
-function marshall(c)
-{
+color.preparePalette = function(relative, bc) {
+  return {
+    prepared: true,
+    original: relative,
+    lab: relative.map(marshall).map(convert.rgb_or_rgba_to_lab.bind(null, bc)),
+  };
+}
+
+function marshall(c) {
   if (typeof c === 'string') {
     return convert.hex_to_rgb(c);
   } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,11 +34,11 @@ color.process = function(target, relative, findFurthest, bc) {
 };
 
 color.closest = function(target, relative, bc) {
-    color.process(target, relative, false, bc);
+    return color.process(target, relative, false, bc);
 }
 
 color.furthest = function(target, relative, bc) {
-    color.process(target, relative, true, bc);
+    return color.process(target, relative, true, bc);
 };
 
 color.closest_lab = function(target, relative) {

--- a/test/convert.js
+++ b/test/convert.js
@@ -126,7 +126,7 @@ describe('convert', function(){
     it('should convert to expected color', function(){
       assert.deepEqual(color_convert.hex_to_rgb("#fFfFfF"), {R: 255, G: 255, B: 255});
       assert.deepEqual(color_convert.hex_to_rgb("#abcdef"), {R: 171, G: 205, B: 239});
-      assert.deepEqual(color_convert.hex_to_rgb("#00000"), {R: 0, G: 0, B: 0});
+      assert.deepEqual(color_convert.hex_to_rgb("#000000"), {R: 0, G: 0, B: 0});
     });
   });
 });

--- a/test/convert.js
+++ b/test/convert.js
@@ -77,7 +77,15 @@ describe('convert', function(){
                                                             'B' : 0,
                                                             'A' : 0.5})));
     });
-  })
+  });
+
+  describe('#hex_to_rgb()', function(){
+    it('should convert to expected color', function(){
+      assert.deepEqual(color_convert.hex_to_rgb("#fFfFfF"), {R: 255, G: 255, B: 255});
+      assert.deepEqual(color_convert.hex_to_rgb("#abcdef"), {R: 171, G: 205, B: 239});
+      assert.deepEqual(color_convert.hex_to_rgb("#00000"), {R: 0, G: 0, B: 0});
+    });
+  });
 });
 
 /**

--- a/test/convert.js
+++ b/test/convert.js
@@ -79,6 +79,49 @@ describe('convert', function(){
     });
   });
 
+  describe('#rgb_or_rgba_to_lab()', function(){
+    const bc = {R: 255, G: 255, B: 255};
+    it('should convert to expected lab color #1', function(){
+      assert.deepEqual({'L' : 40.473, 'a' : -6.106, 'b' : -21.417},
+                       round_all(color_convert.rgb_or_rgba_to_lab(bc, {'R' : 55,
+                                                                       'G' : 100,
+                                                                       'B' : 130})));
+    });
+    it('should convert to expected lab color #2', function(){
+      assert.deepEqual({'L' : 0, 'a' : 0, 'b' : 0},
+                       round_all(color_convert.rgb_or_rgba_to_lab(bc, {'R' : 0,
+                                                                       'G' : 0,
+                                                                       'B' : 0})));
+    });
+    it('should convert to expected lab color #3', function(){
+      assert.deepEqual({'L' : 100, 'a' : 0.005, 'b' : -0.010},
+                       round_all(color_convert.rgb_or_rgba_to_lab(bc, {'R' : 255,
+                                                                       'G' : 255,
+                                                                       'B' : 255})));
+    });
+    it('should convert to expected lab color #4', function(){
+      assert.deepEqual({'L' : 100, 'a' : 0.005, 'b' : -0.010},
+                       round_all(color_convert.rgb_or_rgba_to_lab(bc, {'R' : 255,
+                                                                       'G' : 255,
+                                                                       'B' : 255,
+                                                                       'A' : 1.0})));
+    });
+    it('should convert to expected lab color #5', function(){
+      assert.deepEqual({'L' : 100, 'a' : 0.005, 'b' : -0.010},
+                       round_all(color_convert.rgb_or_rgba_to_lab(bc, {'R' : 0,
+                                                                       'G' : 0,
+                                                                       'B' : 0,
+                                                                       'A' : 0.0})));
+    });
+    it('should convert to expected lab color #6', function(){
+      assert.deepEqual({"L": 53.389, "a": 0.003, "b": -0.006},
+                       round_all(color_convert.rgb_or_rgba_to_lab(bc, {'R' : 0,
+                                                                       'G' : 0,
+                                                                       'B' : 0,
+                                                                       'A' : 0.5})));
+    });
+  });
+
   describe('#hex_to_rgb()', function(){
     it('should convert to expected color', function(){
       assert.deepEqual(color_convert.hex_to_rgb("#fFfFfF"), {R: 255, G: 255, B: 255});

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,133 @@
+/**
+ * IMPORTS
+ */
+var assert        = require('assert');
+var colorDiff     = require('../lib/index');
+var color_convert = require('../lib/convert');
+
+/**
+ * CONSTANTS
+ */
+
+var white   = {'R':255 , 'G':255 ,'B':255};
+var black   = {'R':0   , 'G':0   ,'B':0};
+var navy    = {'R':0   , 'G':0   ,'B':128};
+var blue    = {'R':0   , 'G':0   ,'B':255};
+var yellow  = {'R':255 , 'G':255 ,'B':0};
+var gold    = {'R':255 , 'G':215 ,'B':0};
+
+var whiteHex   = {'R':255 , 'G':255 ,'B':255};
+var blackHex   = {'R':0   , 'G':0   ,'B':0};
+var navyHex    = {'R':0   , 'G':0   ,'B':128};
+var blueHex    = {'R':0   , 'G':0   ,'B':255};
+var yellowHex  = {'R':255 , 'G':255 ,'B':0};
+var goldHex    = {'R':255 , 'G':215 ,'B':0};
+
+var colors1 = [white, black, navy, blue, yellow, gold]
+var colors2 = [white, black, blue, gold]
+var colors3 = [white, black, yellow, blue]
+
+var colors1Hex = [whiteHex, blackHex, navyHex, blueHex, yellowHex, goldHex]
+var colors2Hex = [whiteHex, blackHex, blueHex, goldHex]
+var colors3Hex = [whiteHex, blackHex, yellowHex, blueHex]
+
+var colors1HexPrepared = colorDiff.preparePalette(colors1Hex);
+var colors2HexPrepared = colorDiff.preparePalette(colors2Hex);
+var colors3HexPrepared = colorDiff.preparePalette(colors3Hex);
+
+/**
+ * TESTS
+ */
+
+describe('index', function(){
+  describe('process rgb', function (){
+    it('should find correct closest colors',
+      function() {
+         assert.deepEqual(colorDiff.process(white, colors1), white);
+         assert.deepEqual(colorDiff.process(black, colors1), black);
+         assert.deepEqual(colorDiff.process(navy, colors1), navy);
+         assert.deepEqual(colorDiff.process(blue, colors1), blue);
+         assert.deepEqual(colorDiff.process(yellow, colors1), yellow);
+         assert.deepEqual(colorDiff.process(gold, colors1), gold);
+
+         assert.deepEqual(colorDiff.process(white, colors2), white);
+         assert.deepEqual(colorDiff.process(black, colors2), black);
+         assert.deepEqual(colorDiff.process(navy, colors2), blue);
+         assert.deepEqual(colorDiff.process(blue, colors2), blue);
+         assert.deepEqual(colorDiff.process(yellow, colors2), gold);
+         assert.deepEqual(colorDiff.process(gold, colors2), gold);
+      });
+    it('should find correct furthest colors',
+      function() {
+         assert.deepEqual(colorDiff.process(white, colors3, true), black);
+         assert.deepEqual(colorDiff.process(black, colors3, true), yellow);
+         assert.deepEqual(colorDiff.process(navy, colors3, true), yellow);
+         assert.deepEqual(colorDiff.process(blue, colors3, true), yellow);
+         assert.deepEqual(colorDiff.process(yellow, colors3, true), blue);
+         assert.deepEqual(colorDiff.process(gold, colors3, true), blue);
+      });
+  });
+
+  describe('process hex', function (){
+    it('should find correct closest colors',
+      function() {
+         assert.deepEqual(colorDiff.process(whiteHex, colors1Hex), whiteHex);
+         assert.deepEqual(colorDiff.process(blackHex, colors1Hex), blackHex);
+         assert.deepEqual(colorDiff.process(navyHex, colors1Hex), navyHex);
+         assert.deepEqual(colorDiff.process(blueHex, colors1Hex), blueHex);
+         assert.deepEqual(colorDiff.process(yellowHex, colors1Hex), yellowHex);
+         assert.deepEqual(colorDiff.process(goldHex, colors1Hex), goldHex);
+
+         assert.deepEqual(colorDiff.process(whiteHex, colors2Hex), whiteHex);
+         assert.deepEqual(colorDiff.process(blackHex, colors2Hex), blackHex);
+         assert.deepEqual(colorDiff.process(navyHex, colors2Hex), blueHex);
+         assert.deepEqual(colorDiff.process(blueHex, colors2Hex), blueHex);
+         assert.deepEqual(colorDiff.process(yellowHex, colors2Hex), goldHex);
+         assert.deepEqual(colorDiff.process(goldHex, colors2Hex), goldHex);
+      });
+
+    it('should find correct furthest colors',
+      function() {
+         assert.deepEqual(colorDiff.process(whiteHex, colors3Hex, true), blackHex);
+         assert.deepEqual(colorDiff.process(blackHex, colors3Hex, true), yellowHex);
+         assert.deepEqual(colorDiff.process(navyHex, colors3Hex, true), yellowHex);
+         assert.deepEqual(colorDiff.process(blueHex, colors3Hex, true), yellowHex);
+         assert.deepEqual(colorDiff.process(yellowHex, colors3Hex, true), blueHex);
+         assert.deepEqual(colorDiff.process(goldHex, colors3Hex, true), blueHex);
+      });
+  })
+
+  describe('process hex prepared palette', function (){
+    it('should find correct closest colors',
+      function() {
+         assert.deepEqual(colorDiff.process(whiteHex, colors1HexPrepared), whiteHex);
+         assert.deepEqual(colorDiff.process(blackHex, colors1HexPrepared), blackHex);
+         assert.deepEqual(colorDiff.process(navyHex, colors1HexPrepared), navyHex);
+         assert.deepEqual(colorDiff.process(blueHex, colors1HexPrepared), blueHex);
+         assert.deepEqual(colorDiff.process(yellowHex, colors1HexPrepared), yellowHex);
+         assert.deepEqual(colorDiff.process(goldHex, colors1HexPrepared), goldHex);
+
+         assert.deepEqual(colorDiff.process(whiteHex, colors2HexPrepared), whiteHex);
+         assert.deepEqual(colorDiff.process(blackHex, colors2HexPrepared), blackHex);
+         assert.deepEqual(colorDiff.process(navyHex, colors2HexPrepared), blueHex);
+         assert.deepEqual(colorDiff.process(blueHex, colors2HexPrepared), blueHex);
+         assert.deepEqual(colorDiff.process(yellowHex, colors2HexPrepared), goldHex);
+         assert.deepEqual(colorDiff.process(goldHex, colors2HexPrepared), goldHex);
+      });
+
+    it('should find correct furthest colors',
+      function() {
+         assert.deepEqual(colorDiff.process(whiteHex, colors3HexPrepared, true), blackHex);
+         assert.deepEqual(colorDiff.process(blackHex, colors3HexPrepared, true), yellowHex);
+         assert.deepEqual(colorDiff.process(navyHex, colors3HexPrepared, true), yellowHex);
+         assert.deepEqual(colorDiff.process(blueHex, colors3HexPrepared, true), yellowHex);
+         assert.deepEqual(colorDiff.process(yellowHex, colors3HexPrepared, true), blueHex);
+         assert.deepEqual(colorDiff.process(goldHex, colors3HexPrepared, true), blueHex);
+      });
+  })
+});
+
+// Local Variables:
+// allout-layout: t
+// js-indent-level: 2
+// End:

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,10 @@ var color_convert = require('../lib/convert');
  * CONSTANTS
  */
 
+var pad = s => s.length === 1 ? "0" + s : s;
+var hex = n => pad(n.toString(16));
+var rgb_to_hex = c => `#${hex(c.R)}${hex(c.G)}${hex(c.B)}`;
+
 var white   = {'R':255 , 'G':255 ,'B':255};
 var black   = {'R':0   , 'G':0   ,'B':0};
 var navy    = {'R':0   , 'G':0   ,'B':128};
@@ -16,12 +20,12 @@ var blue    = {'R':0   , 'G':0   ,'B':255};
 var yellow  = {'R':255 , 'G':255 ,'B':0};
 var gold    = {'R':255 , 'G':215 ,'B':0};
 
-var whiteHex   = {'R':255 , 'G':255 ,'B':255};
-var blackHex   = {'R':0   , 'G':0   ,'B':0};
-var navyHex    = {'R':0   , 'G':0   ,'B':128};
-var blueHex    = {'R':0   , 'G':0   ,'B':255};
-var yellowHex  = {'R':255 , 'G':255 ,'B':0};
-var goldHex    = {'R':255 , 'G':215 ,'B':0};
+var whiteHex   = rgb_to_hex({'R':255 , 'G':255 ,'B':255});
+var blackHex   = rgb_to_hex({'R':0   , 'G':0   ,'B':0});
+var navyHex    = rgb_to_hex({'R':0   , 'G':0   ,'B':128});
+var blueHex    = rgb_to_hex({'R':0   , 'G':0   ,'B':255});
+var yellowHex  = rgb_to_hex({'R':255 , 'G':255 ,'B':0});
+var goldHex    = rgb_to_hex({'R':255 , 'G':215 ,'B':0});
 
 var colors1 = [white, black, navy, blue, yellow, gold]
 var colors2 = [white, black, blue, gold]

--- a/test/index.js
+++ b/test/index.js
@@ -40,6 +40,23 @@ var colors3HexPrepared = colorDiff.preparePalette(colors3Hex);
  */
 
 describe('index', function(){
+  describe('#preparePalette', function (){
+    it('should convert hex through to Lab',
+      function() {
+        var original = ["#fFfFfF", "#abcdef", "#000000"];
+        var prepared = colorDiff.preparePalette(original);
+        assert.deepEqual(prepared, {
+          prepared: true,
+          original: original,
+          lab: [
+            color_convert.rgb_to_lab({R: 255, G: 255, B: 255}),
+            color_convert.rgb_to_lab({R: 171, G: 205, B: 239}),
+            color_convert.rgb_to_lab({R: 0, G: 0, B: 0}),
+          ]
+        });
+      });
+  });
+
   describe('process rgb', function (){
     it('should find correct closest colors',
       function() {

--- a/test/index.js
+++ b/test/index.js
@@ -20,35 +20,35 @@ var blue    = {'R':0   , 'G':0   ,'B':255};
 var yellow  = {'R':255 , 'G':255 ,'B':0};
 var gold    = {'R':255 , 'G':215 ,'B':0};
 
-var whiteHex   = rgb_to_hex({'R':255 , 'G':255 ,'B':255});
-var blackHex   = rgb_to_hex({'R':0   , 'G':0   ,'B':0});
-var navyHex    = rgb_to_hex({'R':0   , 'G':0   ,'B':128});
-var blueHex    = rgb_to_hex({'R':0   , 'G':0   ,'B':255});
-var yellowHex  = rgb_to_hex({'R':255 , 'G':255 ,'B':0});
-var goldHex    = rgb_to_hex({'R':255 , 'G':215 ,'B':0});
+var white_hex   = rgb_to_hex({'R':255 , 'G':255 ,'B':255});
+var black_hex   = rgb_to_hex({'R':0   , 'G':0   ,'B':0});
+var navy_hex    = rgb_to_hex({'R':0   , 'G':0   ,'B':128});
+var blue_hex    = rgb_to_hex({'R':0   , 'G':0   ,'B':255});
+var yellow_hex  = rgb_to_hex({'R':255 , 'G':255 ,'B':0});
+var gold_hex    = rgb_to_hex({'R':255 , 'G':215 ,'B':0});
 
 var colors1 = [white, black, navy, blue, yellow, gold]
 var colors2 = [white, black, blue, gold]
 var colors3 = [white, black, yellow, blue]
 
-var colors1Hex = [whiteHex, blackHex, navyHex, blueHex, yellowHex, goldHex]
-var colors2Hex = [whiteHex, blackHex, blueHex, goldHex]
-var colors3Hex = [whiteHex, blackHex, yellowHex, blueHex]
+var colors1_hex = [white_hex, black_hex, navy_hex, blue_hex, yellow_hex, gold_hex]
+var colors2_hex = [white_hex, black_hex, blue_hex, gold_hex]
+var colors3_hex = [white_hex, black_hex, yellow_hex, blue_hex]
 
-var colors1HexPrepared = colorDiff.preparePalette(colors1Hex);
-var colors2HexPrepared = colorDiff.preparePalette(colors2Hex);
-var colors3HexPrepared = colorDiff.preparePalette(colors3Hex);
+var colors1_hex_prepared = colorDiff.prepare_palette(colors1_hex);
+var colors2_hex_prepared = colorDiff.prepare_palette(colors2_hex);
+var colors3_hex_prepared = colorDiff.prepare_palette(colors3_hex);
 
 /**
  * TESTS
  */
 
 describe('index', function(){
-  describe('#preparePalette', function (){
+  describe('#prepare_palette', function (){
     it('should convert hex through to Lab',
       function() {
         var original = ["#fFfFfF", "#abcdef", "#000000"];
-        var prepared = colorDiff.preparePalette(original);
+        var prepared = colorDiff.prepare_palette(original);
         assert.deepEqual(prepared, {
           prepared: true,
           original: original,
@@ -92,58 +92,58 @@ describe('index', function(){
   describe('process hex', function (){
     it('should find correct closest colors',
       function() {
-         assert.deepEqual(colorDiff.closest(whiteHex, colors1Hex), whiteHex);
-         assert.deepEqual(colorDiff.closest(blackHex, colors1Hex), blackHex);
-         assert.deepEqual(colorDiff.closest(navyHex, colors1Hex), navyHex);
-         assert.deepEqual(colorDiff.closest(blueHex, colors1Hex), blueHex);
-         assert.deepEqual(colorDiff.closest(yellowHex, colors1Hex), yellowHex);
-         assert.deepEqual(colorDiff.closest(goldHex, colors1Hex), goldHex);
+         assert.deepEqual(colorDiff.closest(white_hex, colors1_hex), white_hex);
+         assert.deepEqual(colorDiff.closest(black_hex, colors1_hex), black_hex);
+         assert.deepEqual(colorDiff.closest(navy_hex, colors1_hex), navy_hex);
+         assert.deepEqual(colorDiff.closest(blue_hex, colors1_hex), blue_hex);
+         assert.deepEqual(colorDiff.closest(yellow_hex, colors1_hex), yellow_hex);
+         assert.deepEqual(colorDiff.closest(gold_hex, colors1_hex), gold_hex);
 
-         assert.deepEqual(colorDiff.closest(whiteHex, colors2Hex), whiteHex);
-         assert.deepEqual(colorDiff.closest(blackHex, colors2Hex), blackHex);
-         assert.deepEqual(colorDiff.closest(navyHex, colors2Hex), blueHex);
-         assert.deepEqual(colorDiff.closest(blueHex, colors2Hex), blueHex);
-         assert.deepEqual(colorDiff.closest(yellowHex, colors2Hex), goldHex);
-         assert.deepEqual(colorDiff.closest(goldHex, colors2Hex), goldHex);
+         assert.deepEqual(colorDiff.closest(white_hex, colors2_hex), white_hex);
+         assert.deepEqual(colorDiff.closest(black_hex, colors2_hex), black_hex);
+         assert.deepEqual(colorDiff.closest(navy_hex, colors2_hex), blue_hex);
+         assert.deepEqual(colorDiff.closest(blue_hex, colors2_hex), blue_hex);
+         assert.deepEqual(colorDiff.closest(yellow_hex, colors2_hex), gold_hex);
+         assert.deepEqual(colorDiff.closest(gold_hex, colors2_hex), gold_hex);
       });
 
     it('should find correct furthest colors',
       function() {
-         assert.deepEqual(colorDiff.furthest(whiteHex, colors3Hex), blackHex);
-         assert.deepEqual(colorDiff.furthest(blackHex, colors3Hex), yellowHex);
-         assert.deepEqual(colorDiff.furthest(navyHex, colors3Hex), yellowHex);
-         assert.deepEqual(colorDiff.furthest(blueHex, colors3Hex), yellowHex);
-         assert.deepEqual(colorDiff.furthest(yellowHex, colors3Hex), blueHex);
-         assert.deepEqual(colorDiff.furthest(goldHex, colors3Hex), blueHex);
+         assert.deepEqual(colorDiff.furthest(white_hex, colors3_hex), black_hex);
+         assert.deepEqual(colorDiff.furthest(black_hex, colors3_hex), yellow_hex);
+         assert.deepEqual(colorDiff.furthest(navy_hex, colors3_hex), yellow_hex);
+         assert.deepEqual(colorDiff.furthest(blue_hex, colors3_hex), yellow_hex);
+         assert.deepEqual(colorDiff.furthest(yellow_hex, colors3_hex), blue_hex);
+         assert.deepEqual(colorDiff.furthest(gold_hex, colors3_hex), blue_hex);
       });
   })
 
   describe('process hex prepared palette', function (){
     it('should find correct closest colors',
       function() {
-         assert.deepEqual(colorDiff.closest(whiteHex, colors1HexPrepared), whiteHex);
-         assert.deepEqual(colorDiff.closest(blackHex, colors1HexPrepared), blackHex);
-         assert.deepEqual(colorDiff.closest(navyHex, colors1HexPrepared), navyHex);
-         assert.deepEqual(colorDiff.closest(blueHex, colors1HexPrepared), blueHex);
-         assert.deepEqual(colorDiff.closest(yellowHex, colors1HexPrepared), yellowHex);
-         assert.deepEqual(colorDiff.closest(goldHex, colors1HexPrepared), goldHex);
+         assert.deepEqual(colorDiff.closest(white_hex, colors1_hex_prepared), white_hex);
+         assert.deepEqual(colorDiff.closest(black_hex, colors1_hex_prepared), black_hex);
+         assert.deepEqual(colorDiff.closest(navy_hex, colors1_hex_prepared), navy_hex);
+         assert.deepEqual(colorDiff.closest(blue_hex, colors1_hex_prepared), blue_hex);
+         assert.deepEqual(colorDiff.closest(yellow_hex, colors1_hex_prepared), yellow_hex);
+         assert.deepEqual(colorDiff.closest(gold_hex, colors1_hex_prepared), gold_hex);
 
-         assert.deepEqual(colorDiff.closest(whiteHex, colors2HexPrepared), whiteHex);
-         assert.deepEqual(colorDiff.closest(blackHex, colors2HexPrepared), blackHex);
-         assert.deepEqual(colorDiff.closest(navyHex, colors2HexPrepared), blueHex);
-         assert.deepEqual(colorDiff.closest(blueHex, colors2HexPrepared), blueHex);
-         assert.deepEqual(colorDiff.closest(yellowHex, colors2HexPrepared), goldHex);
-         assert.deepEqual(colorDiff.closest(goldHex, colors2HexPrepared), goldHex);
+         assert.deepEqual(colorDiff.closest(white_hex, colors2_hex_prepared), white_hex);
+         assert.deepEqual(colorDiff.closest(black_hex, colors2_hex_prepared), black_hex);
+         assert.deepEqual(colorDiff.closest(navy_hex, colors2_hex_prepared), blue_hex);
+         assert.deepEqual(colorDiff.closest(blue_hex, colors2_hex_prepared), blue_hex);
+         assert.deepEqual(colorDiff.closest(yellow_hex, colors2_hex_prepared), gold_hex);
+         assert.deepEqual(colorDiff.closest(gold_hex, colors2_hex_prepared), gold_hex);
       });
 
     it('should find correct furthest colors',
       function() {
-         assert.deepEqual(colorDiff.furthest(whiteHex, colors3HexPrepared), blackHex);
-         assert.deepEqual(colorDiff.furthest(blackHex, colors3HexPrepared), yellowHex);
-         assert.deepEqual(colorDiff.furthest(navyHex, colors3HexPrepared), yellowHex);
-         assert.deepEqual(colorDiff.furthest(blueHex, colors3HexPrepared), yellowHex);
-         assert.deepEqual(colorDiff.furthest(yellowHex, colors3HexPrepared), blueHex);
-         assert.deepEqual(colorDiff.furthest(goldHex, colors3HexPrepared), blueHex);
+         assert.deepEqual(colorDiff.furthest(white_hex, colors3_hex_prepared), black_hex);
+         assert.deepEqual(colorDiff.furthest(black_hex, colors3_hex_prepared), yellow_hex);
+         assert.deepEqual(colorDiff.furthest(navy_hex, colors3_hex_prepared), yellow_hex);
+         assert.deepEqual(colorDiff.furthest(blue_hex, colors3_hex_prepared), yellow_hex);
+         assert.deepEqual(colorDiff.furthest(yellow_hex, colors3_hex_prepared), blue_hex);
+         assert.deepEqual(colorDiff.furthest(gold_hex, colors3_hex_prepared), blue_hex);
       });
   })
 });

--- a/test/index.js
+++ b/test/index.js
@@ -60,86 +60,86 @@ describe('index', function(){
   describe('process rgb', function (){
     it('should find correct closest colors',
       function() {
-         assert.deepEqual(colorDiff.process(white, colors1), white);
-         assert.deepEqual(colorDiff.process(black, colors1), black);
-         assert.deepEqual(colorDiff.process(navy, colors1), navy);
-         assert.deepEqual(colorDiff.process(blue, colors1), blue);
-         assert.deepEqual(colorDiff.process(yellow, colors1), yellow);
-         assert.deepEqual(colorDiff.process(gold, colors1), gold);
+         assert.deepEqual(colorDiff.closest(white, colors1), white);
+         assert.deepEqual(colorDiff.closest(black, colors1), black);
+         assert.deepEqual(colorDiff.closest(navy, colors1), navy);
+         assert.deepEqual(colorDiff.closest(blue, colors1), blue);
+         assert.deepEqual(colorDiff.closest(yellow, colors1), yellow);
+         assert.deepEqual(colorDiff.closest(gold, colors1), gold);
 
-         assert.deepEqual(colorDiff.process(white, colors2), white);
-         assert.deepEqual(colorDiff.process(black, colors2), black);
-         assert.deepEqual(colorDiff.process(navy, colors2), blue);
-         assert.deepEqual(colorDiff.process(blue, colors2), blue);
-         assert.deepEqual(colorDiff.process(yellow, colors2), gold);
-         assert.deepEqual(colorDiff.process(gold, colors2), gold);
+         assert.deepEqual(colorDiff.closest(white, colors2), white);
+         assert.deepEqual(colorDiff.closest(black, colors2), black);
+         assert.deepEqual(colorDiff.closest(navy, colors2), blue);
+         assert.deepEqual(colorDiff.closest(blue, colors2), blue);
+         assert.deepEqual(colorDiff.closest(yellow, colors2), gold);
+         assert.deepEqual(colorDiff.closest(gold, colors2), gold);
       });
     it('should find correct furthest colors',
       function() {
-         assert.deepEqual(colorDiff.process(white, colors3, true), black);
-         assert.deepEqual(colorDiff.process(black, colors3, true), yellow);
-         assert.deepEqual(colorDiff.process(navy, colors3, true), yellow);
-         assert.deepEqual(colorDiff.process(blue, colors3, true), yellow);
-         assert.deepEqual(colorDiff.process(yellow, colors3, true), blue);
-         assert.deepEqual(colorDiff.process(gold, colors3, true), blue);
+         assert.deepEqual(colorDiff.furthest(white, colors3), black);
+         assert.deepEqual(colorDiff.furthest(black, colors3), yellow);
+         assert.deepEqual(colorDiff.furthest(navy, colors3), yellow);
+         assert.deepEqual(colorDiff.furthest(blue, colors3), yellow);
+         assert.deepEqual(colorDiff.furthest(yellow, colors3), blue);
+         assert.deepEqual(colorDiff.furthest(gold, colors3), blue);
       });
   });
 
   describe('process hex', function (){
     it('should find correct closest colors',
       function() {
-         assert.deepEqual(colorDiff.process(whiteHex, colors1Hex), whiteHex);
-         assert.deepEqual(colorDiff.process(blackHex, colors1Hex), blackHex);
-         assert.deepEqual(colorDiff.process(navyHex, colors1Hex), navyHex);
-         assert.deepEqual(colorDiff.process(blueHex, colors1Hex), blueHex);
-         assert.deepEqual(colorDiff.process(yellowHex, colors1Hex), yellowHex);
-         assert.deepEqual(colorDiff.process(goldHex, colors1Hex), goldHex);
+         assert.deepEqual(colorDiff.closest(whiteHex, colors1Hex), whiteHex);
+         assert.deepEqual(colorDiff.closest(blackHex, colors1Hex), blackHex);
+         assert.deepEqual(colorDiff.closest(navyHex, colors1Hex), navyHex);
+         assert.deepEqual(colorDiff.closest(blueHex, colors1Hex), blueHex);
+         assert.deepEqual(colorDiff.closest(yellowHex, colors1Hex), yellowHex);
+         assert.deepEqual(colorDiff.closest(goldHex, colors1Hex), goldHex);
 
-         assert.deepEqual(colorDiff.process(whiteHex, colors2Hex), whiteHex);
-         assert.deepEqual(colorDiff.process(blackHex, colors2Hex), blackHex);
-         assert.deepEqual(colorDiff.process(navyHex, colors2Hex), blueHex);
-         assert.deepEqual(colorDiff.process(blueHex, colors2Hex), blueHex);
-         assert.deepEqual(colorDiff.process(yellowHex, colors2Hex), goldHex);
-         assert.deepEqual(colorDiff.process(goldHex, colors2Hex), goldHex);
+         assert.deepEqual(colorDiff.closest(whiteHex, colors2Hex), whiteHex);
+         assert.deepEqual(colorDiff.closest(blackHex, colors2Hex), blackHex);
+         assert.deepEqual(colorDiff.closest(navyHex, colors2Hex), blueHex);
+         assert.deepEqual(colorDiff.closest(blueHex, colors2Hex), blueHex);
+         assert.deepEqual(colorDiff.closest(yellowHex, colors2Hex), goldHex);
+         assert.deepEqual(colorDiff.closest(goldHex, colors2Hex), goldHex);
       });
 
     it('should find correct furthest colors',
       function() {
-         assert.deepEqual(colorDiff.process(whiteHex, colors3Hex, true), blackHex);
-         assert.deepEqual(colorDiff.process(blackHex, colors3Hex, true), yellowHex);
-         assert.deepEqual(colorDiff.process(navyHex, colors3Hex, true), yellowHex);
-         assert.deepEqual(colorDiff.process(blueHex, colors3Hex, true), yellowHex);
-         assert.deepEqual(colorDiff.process(yellowHex, colors3Hex, true), blueHex);
-         assert.deepEqual(colorDiff.process(goldHex, colors3Hex, true), blueHex);
+         assert.deepEqual(colorDiff.furthest(whiteHex, colors3Hex), blackHex);
+         assert.deepEqual(colorDiff.furthest(blackHex, colors3Hex), yellowHex);
+         assert.deepEqual(colorDiff.furthest(navyHex, colors3Hex), yellowHex);
+         assert.deepEqual(colorDiff.furthest(blueHex, colors3Hex), yellowHex);
+         assert.deepEqual(colorDiff.furthest(yellowHex, colors3Hex), blueHex);
+         assert.deepEqual(colorDiff.furthest(goldHex, colors3Hex), blueHex);
       });
   })
 
   describe('process hex prepared palette', function (){
     it('should find correct closest colors',
       function() {
-         assert.deepEqual(colorDiff.process(whiteHex, colors1HexPrepared), whiteHex);
-         assert.deepEqual(colorDiff.process(blackHex, colors1HexPrepared), blackHex);
-         assert.deepEqual(colorDiff.process(navyHex, colors1HexPrepared), navyHex);
-         assert.deepEqual(colorDiff.process(blueHex, colors1HexPrepared), blueHex);
-         assert.deepEqual(colorDiff.process(yellowHex, colors1HexPrepared), yellowHex);
-         assert.deepEqual(colorDiff.process(goldHex, colors1HexPrepared), goldHex);
+         assert.deepEqual(colorDiff.closest(whiteHex, colors1HexPrepared), whiteHex);
+         assert.deepEqual(colorDiff.closest(blackHex, colors1HexPrepared), blackHex);
+         assert.deepEqual(colorDiff.closest(navyHex, colors1HexPrepared), navyHex);
+         assert.deepEqual(colorDiff.closest(blueHex, colors1HexPrepared), blueHex);
+         assert.deepEqual(colorDiff.closest(yellowHex, colors1HexPrepared), yellowHex);
+         assert.deepEqual(colorDiff.closest(goldHex, colors1HexPrepared), goldHex);
 
-         assert.deepEqual(colorDiff.process(whiteHex, colors2HexPrepared), whiteHex);
-         assert.deepEqual(colorDiff.process(blackHex, colors2HexPrepared), blackHex);
-         assert.deepEqual(colorDiff.process(navyHex, colors2HexPrepared), blueHex);
-         assert.deepEqual(colorDiff.process(blueHex, colors2HexPrepared), blueHex);
-         assert.deepEqual(colorDiff.process(yellowHex, colors2HexPrepared), goldHex);
-         assert.deepEqual(colorDiff.process(goldHex, colors2HexPrepared), goldHex);
+         assert.deepEqual(colorDiff.closest(whiteHex, colors2HexPrepared), whiteHex);
+         assert.deepEqual(colorDiff.closest(blackHex, colors2HexPrepared), blackHex);
+         assert.deepEqual(colorDiff.closest(navyHex, colors2HexPrepared), blueHex);
+         assert.deepEqual(colorDiff.closest(blueHex, colors2HexPrepared), blueHex);
+         assert.deepEqual(colorDiff.closest(yellowHex, colors2HexPrepared), goldHex);
+         assert.deepEqual(colorDiff.closest(goldHex, colors2HexPrepared), goldHex);
       });
 
     it('should find correct furthest colors',
       function() {
-         assert.deepEqual(colorDiff.process(whiteHex, colors3HexPrepared, true), blackHex);
-         assert.deepEqual(colorDiff.process(blackHex, colors3HexPrepared, true), yellowHex);
-         assert.deepEqual(colorDiff.process(navyHex, colors3HexPrepared, true), yellowHex);
-         assert.deepEqual(colorDiff.process(blueHex, colors3HexPrepared, true), yellowHex);
-         assert.deepEqual(colorDiff.process(yellowHex, colors3HexPrepared, true), blueHex);
-         assert.deepEqual(colorDiff.process(goldHex, colors3HexPrepared, true), blueHex);
+         assert.deepEqual(colorDiff.furthest(whiteHex, colors3HexPrepared), blackHex);
+         assert.deepEqual(colorDiff.furthest(blackHex, colors3HexPrepared), yellowHex);
+         assert.deepEqual(colorDiff.furthest(navyHex, colors3HexPrepared), yellowHex);
+         assert.deepEqual(colorDiff.furthest(blueHex, colors3HexPrepared), yellowHex);
+         assert.deepEqual(colorDiff.furthest(yellowHex, colors3HexPrepared), blueHex);
+         assert.deepEqual(colorDiff.furthest(goldHex, colors3HexPrepared), blueHex);
       });
   })
 });

--- a/test/index.js
+++ b/test/index.js
@@ -9,9 +9,9 @@ var color_convert = require('../lib/convert');
  * CONSTANTS
  */
 
-var pad = s => s.length === 1 ? "0" + s : s;
-var hex = n => pad(n.toString(16));
-var rgb_to_hex = c => `#${hex(c.R)}${hex(c.G)}${hex(c.B)}`;
+var pad = function (s) { return s.length === 1 ? "0" + s : s; };
+var hex = function (n) { return pad(n.toString(16)); }
+var rgb_to_hex = function (c) { return "#" + hex(c.R) + hex(c.G) + hex(c.B); };
 
 var white   = {'R':255 , 'G':255 ,'B':255};
 var black   = {'R':0   , 'G':0   ,'B':0};


### PR DESCRIPTION
This PR builds on #14 (and #13) and allows the user to reap the majority of the performance benefits of #14 without having to work in the Lab-colorspace assuming they're using the same palette over and over (as I am).

Further, this PR allows colors to be input in `#rrggbb` format. It does NOT support `#rgb`, `#rgba`, or `#rrggbbaa` formats at this time (though we could easily do that by switching on the string length).

```
rnd.gen 2.6455512711991234 ± 0.12131436269185036
colorDiff.closest 160.00713217160924 ± 7.918198857054954
colorDiff.closest [predef] 147.80799770923468 ± 4.87628525715313
colorDiff.closest [predef, hex] 165.18798979520074 ± 6.254912585153722
colorDiff.closest [prepared, predef] 40.89235910779613 ± 1.2220039687832747
colorDiff.closest [prepared, predef, hex] 41.27558060008121 ± 1.6421383218742023
lib.palette_lab [predef] 0 ± 0
```

<details>
<summary>Benchmark code</summary>

```js
const Benchmark = require('benchmark');
const colorDiff = require('./lib');

const suite = new Benchmark.Suite;

const rnd = function () {
  return {
    R: Math.floor(Math.random() * 256),
    G: Math.floor(Math.random() * 256),
    B: Math.floor(Math.random() * 256),
  };
};

const rndA = function () {
  return [
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
    rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(), rnd(),
  ];
};

const pad = s => s.length === 1 ? "0" + s : s;
const hex = n => pad(n.toString(16));
const rgb_to_hex = c => `#${hex(c.R)}${hex(c.G)}${hex(c.B)}`;

const predefTarget = rnd();
const predefPalette = rndA();
const predefTargetHex = rgb_to_hex(predefTarget);
const predefPaletteHex = predefPalette.map(rgb_to_hex);
const predefTargetLab = colorDiff.rgb_to_lab(predefTarget);
const predefPaletteLab = predefPalette.map(colorDiff.rgb_to_lab);
const predefPalettePrepared = colorDiff.prepare_palette(predefPalette);
const predefPalettePreparedHex = colorDiff.prepare_palette(predefPaletteHex);

suite
  .add('rnd.gen', function () {
    return [rnd(), rndA()];
  })
  .add('colorDiff.closest', function () {
    return colorDiff.closest(rnd(), rndA());
  })
  .add('colorDiff.closest [predef]', function () {
    return colorDiff.closest(predefTarget, predefPalette);
  })
  .add('colorDiff.closest [predef, hex]', function () {
    return colorDiff.closest(predefTargetHex, predefPaletteHex);
  })
  .add('colorDiff.closest [prepared, predef]', function () {
    return colorDiff.closest(predefTarget, predefPalettePrepared);
  })
  .add('colorDiff.closest [prepared, predef, hex]', function () {
    return colorDiff.closest(predefTargetHex, predefPalettePreparedHex);
  })
  .add('lib.palette_lab [predef]', function () {
    return colorDiff.palette_lab(predefTargetLab, predefPaletteLab, true);
  })
  .on('complete', function () {
    for (let i = 0; i < 7; i += 1) {
      console.log(this[i].name, this[i].stats.mean * 1000000, '±', this[i].stats.deviation * 1000000);
    }
  })
  .run({});
```
</details>