### PR TITLE
Allow lowercase rgb objects, test only with deepStrictEquals

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Returns a mapping from the colors in palette1 to palette2.
 #### color
 `Object`
 
-`color` is an object containing 3 properties: 'R', 'G', 'B', such as:
+`color` is an object containing 3 properties: 'R', 'G', 'B' (case insensitive), such as:
 
 ```js
 { R: 255, G: 1, B: 0 }

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -31,6 +31,7 @@
 */
 exports.rgb_to_lab = rgb_to_lab;
 exports.rgba_to_lab = rgba_to_lab;
+exports.normalize_rgb = normalize_rgb;
 
 /**
 * IMPORTS
@@ -45,13 +46,14 @@ var sqrt = Math.sqrt;
 /**
 * Returns c converted to labcolor. Uses bc as background color,
 * deaults to using white as background color.
-* @param {rgbacolor} c should have fields R,G,B,A
-* @param {rgbcolor} b should have fields R,G,B
+* @param {rgbacolor} c should have fields R,G,B,A (case insensitive)
+* @param {rgbcolor} b should have fields R,G,B (case insensitive)
 * @return {labcolor} c converted to labcolor
 */
 function rgba_to_lab(c, bc)
 {
-  var bc = typeof bc !== 'undefined' ? bc : {R: 255, G: 255, B:255};
+  c = normalize_rgb(c);
+  var bc = typeof bc !== 'undefined' ? normalize_rgb(bc) : {R: 255, G: 255, B:255};
   var new_c = {R: bc.R + (c.R - bc.R) * c.A,
                G: bc.G + (c.G - bc.G) * c.A,
                B: bc.B + (c.B - bc.B) * c.A};
@@ -60,7 +62,7 @@ function rgba_to_lab(c, bc)
 
 /**
 * Returns c converted to labcolor.
-* @param {rgbcolor} c should have fields R,G,B
+* @param {rgbcolor} c should have fields R,G,B (case insensitive)
 * @return {labcolor} c converted to labcolor
 */
 function rgb_to_lab(c)
@@ -69,12 +71,13 @@ function rgb_to_lab(c)
 }
 
 /**
-* Returns c converted to xyzcolor.
-* @param {rgbcolor} c should have fields R,G,B
-* @return {xyzcolor} c converted to xyzcolor
-*/
+ * Returns c converted to xyzcolor.
+ * @param {rgbcolor} c should have fields R,G,B (case insensitive)
+ * @return {xyzcolor} c converted to xyzcolor
+ */
 function rgb_to_xyz(c)
 {
+  c = normalize_rgb(c);
   // Based on http://www.easyrgb.com/index.php?X=MATH&H=02
   var R = ( c.R / 255 );
   var G = ( c.G / 255 );
@@ -122,6 +125,22 @@ function xyz_to_lab(c)
   var a = 500 * ( X - Y );
   var b = 200 * ( Y - Z );
   return {'L' : L , 'a' : a, 'b' : b};
+}
+
+/**
+* Returns c converted to uppercase property names (RGBA from rgba).
+* @param {(rgbcolor|rgbacolor)} c should have fields R,G,B, can have field A (case insensitive)
+* @return {(rgbcolor|rgbacolor)} c convertered to uppercase property names
+*/
+function normalize_rgb(c)
+{
+  var new_c = {R: c.R || c.r || 0,
+               G: c.G || c.g || 0,
+               B: c.B || c.b || 0};
+  if (typeof c.a !== "undefined" || typeof c.A !== "undefined") {
+    new_c.A = c.A || c.a || 0;
+  }
+  return new_c;
 }
 
 // Local Variables:

--- a/lib/palette.js
+++ b/lib/palette.js
@@ -47,11 +47,12 @@ var color_convert = require('./convert');
 
 /**
 * Returns the hash key used for a {rgbcolor} in a {palettemap}
-* @param {rgbcolor} c should have fields R,G,B
+* @param {rgbcolor} c should have fields R,G,B (case insensitive)
 * @return {string}
 */
 function palette_map_key(c)
 {
+  c = color_convert.normalize_rgb(c);
   var s = "R" + c.R + "B" + c.B + "G" + c.G;
   if ("A" in c) {
     s = s + "A" + c.A;
@@ -71,10 +72,10 @@ function lab_palette_map_key(c)
 
 /**
 * Returns a mapping from each color in a to the closest/farthest color in b
-* @param [{rgbcolor}] a each element should have fields R,G,B
-* @param [{rgbcolor}] b each element should have fields R,G,B
-* @param {rgbcolor} Optional background color when using alpha channels
-* @param 'type' should be the string 'closest' or 'furthest'
+* @param [{rgbcolor}] a each element should have fields R,G,B (case insensitive)
+* @param [{rgbcolor}] b each element should have fields R,G,B (case insensitive)
+* @param {('closest'|'furthest')} type should be the string 'closest' or 'furthest'
+* @param {rgbcolor} bc Optional background color when using alpha channels
 * @return {palettemap}
 */
 function map_palette(a, b, type, bc)
@@ -143,7 +144,7 @@ function match_palette_lab(target_color, palette, find_furthest)
 * Returns a mapping from each color in a to the closest color in b
 * @param [{labcolor}] a each element should have fields L,a,b
 * @param [{labcolor}] b each element should have fields L,a,b
-* @param 'type' should be the string 'closest' or 'furthest'
+* @param {('closest'|'furthest')} type should be the string 'closest' or 'furthest'
 * @return {labpalettemap}
 */
 function map_palette_lab(a, b, type)

--- a/test/convert.js
+++ b/test/convert.js
@@ -39,43 +39,66 @@ var color_convert = require('../lib/convert');
 describe('convert', function(){
   describe('#rgb_to_lab()', function(){
     it('should convert to expected lab color #1', function(){
-      assert.deepEqual({'L' : 40.473, 'a' : -6.106, 'b' : -21.417},
-                       round_all(color_convert.rgb_to_lab({'R' : 55,
-                                                           'G' : 100,
-                                                           'B' : 130})));
+      assert.deepStrictEqual({'L' : 40.473, 'a' : -6.106, 'b' : -21.417},
+                             round_all(color_convert.rgb_to_lab({'R' : 55,
+                                                                 'G' : 100,
+                                                                 'B' : 130})));
     });
     it('should convert to expected lab color #2', function(){
-      assert.deepEqual({'L' : 0, 'a' : 0, 'b' : 0},
-                       round_all(color_convert.rgb_to_lab({'R' : 0,
-                                                           'G' : 0,
-                                                           'B' : 0})));
+      assert.deepStrictEqual({'L' : 0, 'a' : 0, 'b' : 0},
+                             round_all(color_convert.rgb_to_lab({'R' : 0,
+                                                                 'G' : 0,
+                                                                 'B' : 0})));
     });
     it('should convert to expected lab color #3', function(){
-      assert.deepEqual({'L' : 100, 'a' : 0.005, 'b' : -0.010},
-                       round_all(color_convert.rgb_to_lab({'R' : 255,
-                                                           'G' : 255,
-                                                           'B' : 255})));
+      assert.deepStrictEqual({'L' : 100, 'a' : 0.005, 'b' : -0.010},
+                             round_all(color_convert.rgb_to_lab({'R' : 255,
+                                                                 'G' : 255,
+                                                                 'B' : 255})));
     });
     it('should convert to expected lab color #4', function(){
-      assert.deepEqual({'L' : 100, 'a' : 0.005, 'b' : -0.010},
-                       round_all(color_convert.rgba_to_lab({'R' : 255,
-                                                            'G' : 255,
-                                                            'B' : 255,
-                                                            'A' : 1.0})));
+      assert.deepStrictEqual({'L' : 100, 'a' : 0.005, 'b' : -0.010},
+                             round_all(color_convert.rgba_to_lab({'R' : 255,
+                                                                  'G' : 255,
+                                                                  'B' : 255,
+                                                                  'A' : 1.0})));
     });
     it('should convert to expected lab color #5', function(){
-      assert.deepEqual({'L' : 100, 'a' : 0.005, 'b' : -0.010},
-                       round_all(color_convert.rgba_to_lab({'R' : 0,
-                                                            'G' : 0,
-                                                            'B' : 0,
-                                                            'A' : 0.0})));
+      assert.deepStrictEqual({'L' : 100, 'a' : 0.005, 'b' : -0.010},
+                             round_all(color_convert.rgba_to_lab({'R' : 0,
+                                                                  'G' : 0,
+                                                                  'B' : 0,
+                                                                  'A' : 0.0})));
     });
     it('should convert to expected lab color #6', function(){
-      assert.deepEqual({"L": 53.389, "a": 0.003, "b": -0.006},
-                       round_all(color_convert.rgba_to_lab({'R' : 0,
-                                                            'G' : 0,
-                                                            'B' : 0,
-                                                            'A' : 0.5})));
+      assert.deepStrictEqual({"L": 53.389, "a": 0.003, "b": -0.006},
+                             round_all(color_convert.rgba_to_lab({'R' : 0,
+                                                                  'G' : 0,
+                                                                  'B' : 0,
+                                                                  'A' : 0.5})));
+    });
+    it('should convert to expected lab color #6 from lowercase RGBA object', function(){
+      assert.deepStrictEqual({"L": 53.389, "a": 0.003, "b": -0.006},
+                             round_all(color_convert.rgba_to_lab({'r' : 0,
+                                                                  'g' : 0,
+                                                                  'b' : 0,
+                                                                  'a' : 0.5})));
+    });
+  })
+
+  describe('#normalize_rgb()', function () {
+    it('should convert lowercase RGB props to uppercase', function () {
+      assert.deepStrictEqual({'R': 55, 'G': 255, 'B': 0},
+                             color_convert.normalize_rgb({'r': 55,
+                                                          'g': 255,
+                                                          'b': 0}));
+    });
+    it('should convert lowercase RGBA props to uppercase', function () {
+      assert.deepStrictEqual({'R': 55, 'G': 255, 'B': 0, 'A': 0},
+                             color_convert.normalize_rgb({'r': 55,
+                                                          'g': 255,
+                                                          'b': 0,
+                                                          'a': 0}));
     });
   })
 });

--- a/test/palette.js
+++ b/test/palette.js
@@ -66,6 +66,14 @@ var yellow_a  = {'R':255 , 'G':255 ,'B':0, 'A': 1.0};
 var gold_a    = {'R':255 , 'G':215 ,'B':0, 'A': 1.0};
 var colors1_a = [white_a, black_a, navy_a, blue_a, yellow_a, gold_a]
 
+var white_a_lower   = {'r':255 , 'g':255 ,'b':255, 'a': 1.0};
+var black_a_lower   = {'r':0   , 'g':0   ,'b':0, 'a': 1.0};
+var navy_a_lower    = {'r':0   , 'g':0   ,'b':128, 'a': 1.0};
+var blue_a_lower    = {'r':0   , 'g':0   ,'b':255, 'a': 1.0};
+var yellow_a_lower  = {'r':255 , 'g':255 ,'b':0, 'a': 1.0};
+var gold_a_lower    = {'r':255 , 'g':215 ,'b':0, 'a': 1.0};
+var colors1_a_lower = [white_a_lower, black_a_lower, navy_a_lower, blue_a_lower, yellow_a_lower, gold_a_lower]
+
 var white_a_lab   = color_convert.rgb_to_lab(white_a);
 var black_a_lab   = color_convert.rgb_to_lab(black_a);
 var navy_a_lab    = color_convert.rgb_to_lab(navy_a);
@@ -89,8 +97,8 @@ describe('palette', function(){
          expected1_1[color_palette.palette_map_key(blue)]   = blue;
          expected1_1[color_palette.palette_map_key(yellow)] = yellow;
          expected1_1[color_palette.palette_map_key(gold)]   = gold;
-         assert.deepEqual(expected1_1,
-                          color_palette.map_palette(colors1, colors1));
+         assert.deepStrictEqual(expected1_1,
+                                color_palette.map_palette(colors1, colors1));
        });
     it('should map all colors to themselves when possible #2',
        function(){
@@ -101,8 +109,8 @@ describe('palette', function(){
          expected1_2[color_palette.palette_map_key(blue_a)]   = blue_a;
          expected1_2[color_palette.palette_map_key(yellow_a)] = yellow_a;
          expected1_2[color_palette.palette_map_key(gold_a)]   = gold_a;
-         assert.deepEqual(expected1_2,
-                          color_palette.map_palette(colors1_a, colors1_a));
+         assert.deepStrictEqual(expected1_2,
+                                color_palette.map_palette(colors1_a, colors1_a));
        });
     it('should map navy->blue and yellow->gold when navy and yellow are missing',
        function(){
@@ -113,8 +121,8 @@ describe('palette', function(){
          expected2[color_palette.palette_map_key(blue)]   = blue;
          expected2[color_palette.palette_map_key(yellow)] = gold;
          expected2[color_palette.palette_map_key(gold)]   = gold;
-         assert.deepEqual(expected2,
-                          color_palette.map_palette(colors1, colors2));
+         assert.deepStrictEqual(expected2,
+                                color_palette.map_palette(colors1, colors2));
        });
     it('should map white->black & black,navy,blue->yellow & yellow,gold->blue',
        function(){
@@ -125,12 +133,23 @@ describe('palette', function(){
          expected3[color_palette.palette_map_key(blue)]   = yellow;
          expected3[color_palette.palette_map_key(yellow)] = blue;
          expected3[color_palette.palette_map_key(gold)]   = blue;
-         assert.deepEqual(expected3,
-                          color_palette.map_palette(colors1,
-                                                    colors3,
-                                                    'furthest'));
+         assert.deepStrictEqual(expected3,
+                                color_palette.map_palette(colors1,
+                                                          colors3,
+                                                          'furthest'));
        });
-
+       it('should map all colors to their uppercase versions when lowercase RGBA was inputted',
+       function(){
+         var expected4                                      = {};
+         expected4[color_palette.palette_map_key(white_a_lower)]  = white_a;
+         expected4[color_palette.palette_map_key(black_a_lower)]  = black_a;
+         expected4[color_palette.palette_map_key(navy_a_lower)]   = navy_a;
+         expected4[color_palette.palette_map_key(blue_a_lower)]   = blue_a;
+         expected4[color_palette.palette_map_key(yellow_a_lower)] = yellow_a;
+         expected4[color_palette.palette_map_key(gold_a_lower)]   = gold_a;
+         assert.deepStrictEqual(expected4,
+                                color_palette.map_palette(colors1_a_lower, colors1_a, 'closest', white_a_lower));
+       });
   })
 
   describe('#map_palette_lab()', function (){
@@ -143,8 +162,8 @@ describe('palette', function(){
          expected1_1[color_palette.lab_palette_map_key(blue_lab)]   = blue_lab;
          expected1_1[color_palette.lab_palette_map_key(yellow_lab)] = yellow_lab;
          expected1_1[color_palette.lab_palette_map_key(gold_lab)]   = gold_lab;
-         assert.deepEqual(expected1_1,
-                          color_palette.map_palette_lab(colors1_lab, colors1_lab));
+         assert.deepStrictEqual(expected1_1,
+                                color_palette.map_palette_lab(colors1_lab, colors1_lab));
        });
     it('should map all colors to themselves when possible #2',
        function(){
@@ -155,8 +174,8 @@ describe('palette', function(){
          expected1_2[color_palette.lab_palette_map_key(blue_a_lab)]   = blue_a_lab;
          expected1_2[color_palette.lab_palette_map_key(yellow_a_lab)] = yellow_a_lab;
          expected1_2[color_palette.lab_palette_map_key(gold_a_lab)]   = gold_a_lab;
-         assert.deepEqual(expected1_2,
-                          color_palette.map_palette_lab(colors1_a_lab, colors1_a_lab));
+         assert.deepStrictEqual(expected1_2,
+                                color_palette.map_palette_lab(colors1_a_lab, colors1_a_lab));
        });
     it('should map navy->blue and yellow->gold when navy and yellow are missing',
        function(){
@@ -167,8 +186,8 @@ describe('palette', function(){
          expected2[color_palette.lab_palette_map_key(blue_lab)]   = blue_lab;
          expected2[color_palette.lab_palette_map_key(yellow_lab)] = gold_lab;
          expected2[color_palette.lab_palette_map_key(gold_lab)]   = gold_lab;
-         assert.deepEqual(expected2,
-                          color_palette.map_palette_lab(colors1_lab, colors2_lab));
+         assert.deepStrictEqual(expected2,
+                                color_palette.map_palette_lab(colors1_lab, colors2_lab));
        });
     it('should map white->black & black,navy,blue->yellow & yellow,gold->blue',
        function(){
@@ -179,10 +198,10 @@ describe('palette', function(){
          expected3[color_palette.lab_palette_map_key(blue_lab)]   = yellow_lab;
          expected3[color_palette.lab_palette_map_key(yellow_lab)] = blue_lab;
          expected3[color_palette.lab_palette_map_key(gold_lab)]   = blue_lab;
-         assert.deepEqual(expected3,
-                          color_palette.map_palette_lab(colors1_lab,
-                                                    colors3_lab,
-                                                    'furthest'));
+         assert.deepStrictEqual(expected3,
+                                color_palette.map_palette_lab(colors1_lab,
+                                                              colors3_lab,
+                                                              'furthest'));
        });
 
   })
@@ -190,29 +209,29 @@ describe('palette', function(){
   describe('#match_palette_lab()', function (){
     it('should match map_palette results for closest',
       function() {
-         assert.deepEqual(color_palette.match_palette_lab(white_lab, colors1_lab), white_lab);
-         assert.deepEqual(color_palette.match_palette_lab(black_lab, colors1_lab), black_lab);
-         assert.deepEqual(color_palette.match_palette_lab(navy_lab, colors1_lab), navy_lab);
-         assert.deepEqual(color_palette.match_palette_lab(blue_lab, colors1_lab), blue_lab);
-         assert.deepEqual(color_palette.match_palette_lab(yellow_lab, colors1_lab), yellow_lab);
-         assert.deepEqual(color_palette.match_palette_lab(gold_lab, colors1_lab), gold_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(white_lab, colors1_lab), white_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(black_lab, colors1_lab), black_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(navy_lab, colors1_lab), navy_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(blue_lab, colors1_lab), blue_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(yellow_lab, colors1_lab), yellow_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(gold_lab, colors1_lab), gold_lab);
 
-         assert.deepEqual(color_palette.match_palette_lab(white_lab, colors2_lab), white_lab);
-         assert.deepEqual(color_palette.match_palette_lab(black_lab, colors2_lab), black_lab);
-         assert.deepEqual(color_palette.match_palette_lab(navy_lab, colors2_lab), blue_lab);
-         assert.deepEqual(color_palette.match_palette_lab(blue_lab, colors2_lab), blue_lab);
-         assert.deepEqual(color_palette.match_palette_lab(yellow_lab, colors2_lab), gold_lab);
-         assert.deepEqual(color_palette.match_palette_lab(gold_lab, colors2_lab), gold_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(white_lab, colors2_lab), white_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(black_lab, colors2_lab), black_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(navy_lab, colors2_lab), blue_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(blue_lab, colors2_lab), blue_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(yellow_lab, colors2_lab), gold_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(gold_lab, colors2_lab), gold_lab);
       });
 
     it('should match map_palette results for furthest',
       function() {
-         assert.deepEqual(color_palette.match_palette_lab(white_lab, colors3_lab, true), black_lab);
-         assert.deepEqual(color_palette.match_palette_lab(black_lab, colors3_lab, true), yellow_lab);
-         assert.deepEqual(color_palette.match_palette_lab(navy_lab, colors3_lab, true), yellow_lab);
-         assert.deepEqual(color_palette.match_palette_lab(blue_lab, colors3_lab, true), yellow_lab);
-         assert.deepEqual(color_palette.match_palette_lab(yellow_lab, colors3_lab, true), blue_lab);
-         assert.deepEqual(color_palette.match_palette_lab(gold_lab, colors3_lab, true), blue_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(white_lab, colors3_lab, true), black_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(black_lab, colors3_lab, true), yellow_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(navy_lab, colors3_lab, true), yellow_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(blue_lab, colors3_lab, true), yellow_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(yellow_lab, colors3_lab, true), blue_lab);
+         assert.deepStrictEqual(color_palette.match_palette_lab(gold_lab, colors3_lab, true), blue_lab);
       });
   })
 });


### PR DESCRIPTION
Fixes #17
- Normalizes lowercase RGB/RGBA input to uppercase before any property access on a color object.
- Added tests and a documentation change

Other
- All tests now use `assert.deepStrictEqual` instead of `deepEqual` since everything passes and the [API is deprecated](https://nodejs.org/api/assert.html#assert_assert_deepequal_actual_expected_message)
- Minor changes to relevant jsdoc