### PR TITLE
Proof of Concept: Test one function using testy

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -52,6 +52,18 @@ var PI = Math.PI;
 * @param {labcolor} c1    Should have fields L,a,b
 * @param {labcolor} c2    Should have fields L,a,b
 * @return {float}   Difference between c1 and c2
+* @example
+* // It uses the true chroma difference (#1)
+* ciede2000({
+*   L: 50.0000,
+*   a: 2.6772,
+*   b: -79.7751
+* }, {
+*   L: 50.0000,
+*   a: 0.0000,
+*   b: -82.7485
+* }).toFixed(4)
+* //=> "2.0425"
 */
 function ciede2000(c1,c2)
 {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
     "url": "https://github.com/markusn/color-diff/issues"
   },
   "devDependencies": {
+    "@linus/testy": "^1.1.0",
     "assert": "~1.4.1",
-    "mocha": "~5.0.4",
     "coveralls": "~3.0.0",
-    "istanbul": "~0.4.5"
+    "istanbul": "~0.4.5",
+    "mocha": "~5.0.4"
   }
 }

--- a/test/doctests.js
+++ b/test/doctests.js
@@ -1,0 +1,5 @@
+import('@linus/testy').then(({ testy }) => {
+  describe('Test', () => {
+    testy('lib/diff.js');
+  });
+});


### PR DESCRIPTION
This is just a PoC to show the feasability of doctest:ing the JSDoc
@examples instead of / in addition to other tests.

Because of require/import discrepancies, the test scaffolding needs
some import shenanigans.

Apart from that, the rounding needs to be handled somewhat differently.
This could be solved in other ways, if given a feature request to testy:
- One could imagine the option to inject different expect-logic in the
test suite (make expect behave more fuzzy).
- Or, the option of injecting a helper function to use in @examples.
- ... or other options.

In anticipation of a more thorough effort, though, it seems pertinent
to update and modernize the project first, though.

Nice library! 🙌